### PR TITLE
Add support for pre-population of Contents.swift

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Simply run `playground` in your terminal, and you’ll have a playground opened 
 To install `playground`, simply run the following command in your terminal of choice:
 
 ```
-$ curl https://raw.githubusercontent.com/JohnSundell/playground/master/playground > /usr/local/bin/playground; chmod +x /usr/local/bin/playground
+$ curl https://raw.githubusercontent.com/cameroncooke/playground/master/playground > /usr/local/bin/playground; chmod +x /usr/local/bin/playground
 ```
 
 ### Documentation

--- a/playground
+++ b/playground
@@ -5,7 +5,10 @@ if [[ $1 == "-h" ]] || [[ $1 == "--help" ]]
     then
     echo "Playground"
     echo "----------"
-    echo "Easily create Swift playgrounds from the command line"
+    echo "Easily create Swift playgrounds from the command line."
+    echo ""
+    echo "Optionally accepts input from stdIn to prepopulate playground, e.g."
+    echo "cat source.swift | playground"
     echo ""
     echo "Options:"
     echo "   -f   [File path]   Create or open a playground at the specified path (default: ~/Desktop/[Date].playground)"
@@ -71,8 +74,14 @@ case $PLATFORM in
     *) FRAMEWORK="Foundation" ;;
 esac
 
-# Create the Contents.swift file
-printf "import $FRAMEWORK\n\n" > Contents.swift
+if [ -t 0 ] ; then
+  # Create the Contents.swift file
+  printf "import $FRAMEWORK\n\n" > Contents.swift
+else
+  # Receive input from stdIn
+  INPUT=$(</dev/stdin)
+  printf "import $FRAMEWORK\n\n$INPUT" > Contents.swift
+fi
 
 # Create timeline file
 echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Timeline version=\"3.0\"><TimelineItems></TimelineItems></Timeline>" > timeline.xctimeline

--- a/playground
+++ b/playground
@@ -27,7 +27,7 @@ done
 # Default file path & .playground suffix
 if [ -z "$FILE_PATH" ]
     then
-    datetime=$(date "+%d-%m-%Y")
+    datetime=$(date "+%d-%m-%Y_%H-%M-%S")
     FILE_PATH="~/Desktop/$datetime.playground"
 else
     case $FILE_PATH in


### PR DESCRIPTION
I've modified the script to support the pre-populatation of  the `Contents.swift` from input passed via stdIn.

This means that you can essentially start with a standard template e.g.

```bash
cat source.swift | playground
```

Running `playground` without piping input will result in the script behaving exactly as it does currently. The user will never be prompted for input.

My actual use-case for this was because I wanted to create an Automator script that passes in the selected text to the script via stdIn and creates a playground with the Contents.swift pre-populated with the selected text. 

I then use this service to allow me to select source-code examples in iBooks and paste them into a new Playground. This is because iBooks on the Mac prevents copy & paste but allows macOS services to process selected text.

<img width="636" alt="screen shot 2017-04-04 at 13 47 42" src="https://cloud.githubusercontent.com/assets/630601/24657210/4f4ed80e-193d-11e7-9685-bc5123ad71f3.png">

Which is as simple as creating the automator service above and running the updated `playground` script.

I've also modified the script to add the time to the filename so that a new playground is created each time. Though just thinking now about how this might be used it might be better to add an option for this.
