### PR TITLE
Force date filename to not contain slashes

### DIFF
--- a/Sources/Playground.swift
+++ b/Sources/Playground.swift
@@ -25,7 +25,8 @@ extension Date {
     var today: String {
         let formatter = DateFormatter()
         formatter.dateStyle = .short
-        return formatter.string(from: self)
+        let date = formatter.string(from: self)
+        return date.replacingOccurrences(of: "/", with: "-")
     }
 }
 


### PR DESCRIPTION
Fixes #9

I've fixed this by just replacing any `/` with `-`.

I did not want to set a specific locale because the date format should still follow the users locale, but I could not find a way to change just the date component separator either through `Locale` or `DateFormatter`.