### PR TITLE
Add support for directory names with spaces

### DIFF
--- a/Sources/Playground.swift
+++ b/Sources/Playground.swift
@@ -17,7 +17,7 @@ extension CommandLine {
 
     static func open(path: String) throws {
         print("🚀  Opening \(path)...")
-        try shellOut(to: "open \(path)")
+        try shellOut(to: "open \"\(path)\"")
     }
 }
 


### PR DESCRIPTION
Adds the ability to use directory names that has spaces in it. Currently the playground is created successfully but opening it fails as it evaluates the path as two different arguments. This way we can save our playgrounds in iCloud Drive.

```
playground -t “/Users/[username]/Library/Mobile\ Documents/com~apple~CloudDocs/Playgrounds”
```