### PR TITLE
Revert "Add support for directory names with spaces"

### DIFF
--- a/Sources/Playground.swift
+++ b/Sources/Playground.swift
@@ -17,7 +17,7 @@ extension CommandLine {
 
     static func open(path: String) throws {
         print("🚀  Opening \(path)...")
-        try shellOut(to: "open \"\(path)\"")
+        try shellOut(to: "open \(path)")
     }
 }
 


### PR DESCRIPTION
Reverts JohnSundell/Playground#12. After merging this no playgrounds could be created on the desktop (or in any path containing `~`)