### PR TITLE
Default project creation to current directory path instead of Desktop

### DIFF
--- a/Sources/Playground/main.swift
+++ b/Sources/Playground/main.swift
@@ -188,7 +188,7 @@ struct Options {
     var displayHelp = false
 
     init(arguments: [String] = CommandLine.argumentsExcludingLaunchPath) throws {
-        let defaultTargetPath = "~/Desktop/\(Date().today).playground"
+        let defaultTargetPath = FileManager.default.currentDirectoryPath + "/\(Date().today).playground"
         targetPath = defaultTargetPath
 
         var currentFlag: Flag?
@@ -302,7 +302,7 @@ func displayHelp() {
         Options:
 
         📁  -t  Specify a target path where the playground should be created
-                Default: ~/Desktop/<Date>
+                Default: <currentDirectoryPath>/<Date>
         📱  -p  Select platform (iOS, macOS or tvOS) that the playground should run on
                 Default: iOS
         🏃‍♂️  -a  Turn on auto run for the generated playground


### PR DESCRIPTION
This will change the default path where a playground is created upon invoking `playground` command  to the current working directory instead of Desktop. 

 The reasons for this change are:- 
1).  It will make it easy to locate the newly created file as it will be inside the current directory where user run the `playground` command instead of going all the way up  to Desktop.

2).  Many people who prefer to create stuffs via CLI(myself included) are expecting any changes such as adding new files or folders to happen in the current working directory as long as they didn't specify another path manually.

In addition to the above mentioned change, I have also updated the description returned after invoking `playground -h` to match the above suggested change. 
Thank you :) 